### PR TITLE
Optional `likeItem` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is Ember cli addon which provide twitter like favourite heart component.
  This addon provides an `ember-inplace-edit` component.
 
 ```handlebars
-{{ember-favourite-heart liked=model.liked likeCount=model.likes_count action="toggleLike"}}
+{{ember-favourite-heart liked=model.liked likeCount=model.likes_count likeItem=model action="toggleLike"}}
   
 ```
 
@@ -46,6 +46,10 @@ This is Ember cli addon which provide twitter like favourite heart component.
   <tr>
     <td valign="top"><code>action</code></td>
     <td valign="top">Action to be called after clicking on heart</tr>
+  </tr>
+  <tr>
+    <td valign="top"><code>likeItem</code></td>
+    <td valign="top">Optional parameter passed with action</tr>
   </tr>
 </table>
 

--- a/addon/components/ember-favourite-heart.js
+++ b/addon/components/ember-favourite-heart.js
@@ -7,7 +7,7 @@ export default Ember.Component.extend({
   likeCount: 0,
   disabled: false,
 
-  heartClass: Ember.computed('liked', function() { 
+  heartClass: Ember.computed('liked', function() {
     if(this.get('liked')){
       return "heart heartAnimation";
     }else{
@@ -41,7 +41,11 @@ export default Ember.Component.extend({
         }else{
           this.like();
         }
-        this.sendAction();
+        if (this.get('likeItem')) {
+          this.sendAction('action', this.get('likeItem'));
+        } else {
+          this.sendAction();
+        }
       }
     }
   }


### PR DESCRIPTION
This is helpful especially when you need to deal with arrays.

In Ember newer versions you could do something like that: `{{ember-favourite-heart liked=model.liked likeCount=model.likes_count action=(action "toggleLike" model)}}` but I prefer implicit approach: `{{ember-favourite-heart liked=model.liked likeCount=model.likes_count likeItem=model action="toggleLike"}}` with optional `likeItem` parameter.

@anilmaurya what do you think about that?
